### PR TITLE
Random number generation refactor

### DIFF
--- a/lpt/cube.py
+++ b/lpt/cube.py
@@ -3,15 +3,14 @@ import sys
 import os
 import gc
 
-import scaleran as sr
-
 import jax.numpy as jnp 
-import jax.random as rnd
+
 
 class Cube:
     '''Cube'''
-    def __init__(self, **kwargs):
+    def __init__(self, stream, **kwargs):
 
+        self.stream  = stream
         self.N       = kwargs.get('N',512)
         self.Lbox    = kwargs.get('Lbox',7700.0)
         self.partype = kwargs.get('partype','jaxshard')
@@ -69,20 +68,19 @@ class Cube:
         interp_fcn = jnp.interp(interp_fcn, k_1d, f_1d, left='extrapolate', right='extrapolate')
         return jnp.reshape(interp_fcn, self.cshape_local).astype(jnp.float32)
 
-    def _generate_sharded_noise(self, N, noisetype, seed, nsub):           
+    def _generate_sharded_noise(self, N, noisetype, mc):           
         ngpus   = self.ngpus
         host_id = self.host_id
         start   = self.start
         end     = self.end
 
-        stream = sr.Stream(seed=seed,nsub=nsub)
-        noise = stream.generate(start=start*N**2,size=(end-start)*N**2).astype(jnp.float32)
+        noise = self.stream.generate(start=start*N**2,size=(end-start)*N**2, mc=mc, dist=noisetype, dtype=jnp.float32)
         noise = jnp.reshape(noise,(end-start,N,N))
         return jnp.transpose(noise,(1,0,2)) 
 
-    def _generate_serial_noise(self, N, noisetype, seed, nsub):
-        stream = sr.Stream(seed=seed,nsub=nsub)
-        noise = stream.generate(start=0,size=N**3).astype(jnp.float32)
+    def _generate_serial_noise(self, N, noisetype, mc):
+        
+        noise = self.stream.generate(start=0,size=N**3, mc=mc, dist=noisetype, dtype=jnp.float32)
         noise = jnp.reshape(noise,(N,N,N))
         return jnp.transpose(noise,(1,0,2))
 
@@ -140,15 +138,15 @@ class Cube:
                 local_out_subset = out_jit.addressable_data(0)
         return local_out_subset
 
-    def generate_noise(self, noisetype='white', nsub=1024**3, seed=13579):
+    def generate_noise(self, noisetype='normal', mc=0):
 
         N = self.N
 
         noise = None
         if self.partype is None:
-            noise = self._generate_serial_noise(N, noisetype, seed, nsub)
+            noise = self._generate_serial_noise(N, noisetype, mc=mc)
         elif self.partype == 'jaxshard':
-            noise = self._generate_sharded_noise(N, noisetype, seed, nsub)
+            noise = self._generate_sharded_noise(N, noisetype, mc=mc)
         return noise
 
     def noise2delta(self, delta, transfer):

--- a/lpt/cube.py
+++ b/lpt/cube.py
@@ -8,9 +8,9 @@ import jax.numpy as jnp
 
 class Cube:
     '''Cube'''
-    def __init__(self, stream_method, **kwargs):
+    def __init__(self, stream, **kwargs):
 
-        self.stream_method  = stream_method
+        self.stream         = stream
         self.N              = kwargs.get('N',512)
         self.Lbox           = kwargs.get('Lbox',7700.0)
         self.partype        = kwargs.get('partype','jaxshard')
@@ -74,7 +74,7 @@ class Cube:
         start   = self.start
         end     = self.end
 
-        noise = self.stream_method(start=start*N**2,size=(end-start)*N**2, mc=mc, dist=noisetype, dtype=jnp.float32)
+        noise = self.stream.generate(start=start*N**2,size=(end-start)*N**2, mc=mc, dist=noisetype, dtype=jnp.float32)
         noise = jnp.reshape(noise,(end-start,N,N))
         return jnp.transpose(noise,(1,0,2)) 
 

--- a/lpt/cube.py
+++ b/lpt/cube.py
@@ -74,13 +74,13 @@ class Cube:
         start   = self.start
         end     = self.end
 
-        noise = self.stream.generate(start=start*N**2,size=(end-start)*N**2, mc=mc, dist=noisetype, dtype=jnp.float32)
+        noise = self.stream.generate(start=start*N**2,size=(end-start)*N**2, mc=mc, dist=noisetype)
         noise = jnp.reshape(noise,(end-start,N,N))
         return jnp.transpose(noise,(1,0,2)) 
 
     def _generate_serial_noise(self, N, noisetype, mc):
         
-        noise = self.stream_method(start=0,size=N**3, mc=mc, dist=noisetype, dtype=jnp.float32)
+        noise = self.stream.generate(start=0,size=N**3, mc=mc, dist=noisetype)
         noise = jnp.reshape(noise,(N,N,N))
         return jnp.transpose(noise,(1,0,2))
 

--- a/lpt/cube.py
+++ b/lpt/cube.py
@@ -8,12 +8,12 @@ import jax.numpy as jnp
 
 class Cube:
     '''Cube'''
-    def __init__(self, stream, **kwargs):
+    def __init__(self, stream_method, **kwargs):
 
-        self.stream  = stream
-        self.N       = kwargs.get('N',512)
-        self.Lbox    = kwargs.get('Lbox',7700.0)
-        self.partype = kwargs.get('partype','jaxshard')
+        self.stream_method  = stream_method
+        self.N              = kwargs.get('N',512)
+        self.Lbox           = kwargs.get('Lbox',7700.0)
+        self.partype        = kwargs.get('partype','jaxshard')
 
         self.k0 = 2*jnp.pi/self.Lbox
 
@@ -74,13 +74,13 @@ class Cube:
         start   = self.start
         end     = self.end
 
-        noise = self.stream.generate(start=start*N**2,size=(end-start)*N**2, mc=mc, dist=noisetype, dtype=jnp.float32)
+        noise = self.stream_method(start=start*N**2,size=(end-start)*N**2, mc=mc, dist=noisetype, dtype=jnp.float32)
         noise = jnp.reshape(noise,(end-start,N,N))
         return jnp.transpose(noise,(1,0,2)) 
 
     def _generate_serial_noise(self, N, noisetype, mc):
         
-        noise = self.stream.generate(start=0,size=N**3, mc=mc, dist=noisetype, dtype=jnp.float32)
+        noise = self.stream_method(start=0,size=N**3, mc=mc, dist=noisetype, dtype=jnp.float32)
         noise = jnp.reshape(noise,(N,N,N))
         return jnp.transpose(noise,(1,0,2))
 

--- a/scripts/example.py
+++ b/scripts/example.py
@@ -64,7 +64,7 @@ task_tag = "MPI process "+str(mpiproc)
 if MPI.COMM_WORLD.Get_size() > 1: parallel = True
 
 RNG_manager = mu.RNG_manager()
-IC_rand_stream = RNG_manager.setup_stream('ic_grid')
+IC_rand_stream = RNG_manager.setup_stream('ic_grid', dtype=jnp.float32)
 
 if not parallel:
     cube = lpt.Cube(IC_rand_stream.generate, N=N,partype=None)  

--- a/scripts/example.py
+++ b/scripts/example.py
@@ -61,7 +61,10 @@ mpiproc  = MPI.COMM_WORLD.Get_rank()
 comm     = MPI.COMM_WORLD
 task_tag = "MPI process "+str(mpiproc)
 
-if MPI.COMM_WORLD.Get_size() > 1: parallel = True
+if MPI.COMM_WORLD.Get_size() > 1: 
+    parallel = True
+    jax.distributed.initialize()
+    print(f'Global mumber of devices {jax.device_count()}')
 
 RNG_manager = mu.RNG_manager()
 IC_rand_stream = RNG_manager.setup_stream('ic_grid', dtype=jnp.float32)
@@ -69,8 +72,6 @@ IC_rand_stream = RNG_manager.setup_stream('ic_grid', dtype=jnp.float32)
 if not parallel:
     cube = lpt.Cube(IC_rand_stream, N=N,partype=None)  
 else:
-    jax.distributed.initialize()
-    print(f'Global mumber of devices {jax.device_count()}')
     cube = lpt.Cube(IC_rand_stream, N=N)
 times = _profiletime(None, 'initialization', times, comm, mpiproc)
 

--- a/scripts/example.py
+++ b/scripts/example.py
@@ -67,7 +67,7 @@ RNG_manager = mu.RNG_manager()
 IC_rand_stream = RNG_manager.setup_stream('ic_grid')
 
 if not parallel:
-    cube = lpt.Cube(IC_rand_stream, N=N,partype=None)  
+    cube = lpt.Cube(IC_rand_stream.generate, N=N,partype=None)  
 else:
     jax.distributed.initialize()
     cube = lpt.Cube(IC_rand_stream, N=N)

--- a/scripts/example.py
+++ b/scripts/example.py
@@ -67,9 +67,10 @@ RNG_manager = mu.RNG_manager()
 IC_rand_stream = RNG_manager.setup_stream('ic_grid', dtype=jnp.float32)
 
 if not parallel:
-    cube = lpt.Cube(IC_rand_stream.generate, N=N,partype=None)  
+    cube = lpt.Cube(IC_rand_stream, N=N,partype=None)  
 else:
     jax.distributed.initialize()
+    print(f'Global mumber of devices {jax.device_count()}')
     cube = lpt.Cube(IC_rand_stream, N=N)
 times = _profiletime(None, 'initialization', times, comm, mpiproc)
 

--- a/scripts/example.py
+++ b/scripts/example.py
@@ -1,6 +1,7 @@
 import jax
 import lpt
 from mpi4py import MPI
+import xgmutil as mu
 import argparse
 import sys
 from time import time
@@ -45,12 +46,14 @@ parser = argparse.ArgumentParser(description='Commandline interface to lpt4py ex
 parser.add_argument('--N',     type=int, help='grid dimention [default = 512]', default=512)
 parser.add_argument('--seed',  type=int, help='random seed [default = 13579]',  default=13579)
 parser.add_argument('--ityp',  type=str, help='lpt input type [default = delta]',  default='delta')
+parser.add_argument('--mc',     type=int, help='MC realization no. [default = 0]', default=0)
 
 args = parser.parse_args()
 
 N    = args.N
 seed = args.seed
 ityp = args.ityp
+mc   = args.mc
 
 parallel = False
 nproc    = MPI.COMM_WORLD.Get_size()
@@ -60,15 +63,18 @@ task_tag = "MPI process "+str(mpiproc)
 
 if MPI.COMM_WORLD.Get_size() > 1: parallel = True
 
+RNG_manager = mu.RNG_manager()
+IC_rand_stream = RNG_manager.setup_stream('ic_grid')
+
 if not parallel:
-    cube = lpt.Cube(N=N,partype=None)  
+    cube = lpt.Cube(IC_rand_stream, N=N,partype=None)  
 else:
     jax.distributed.initialize()
-    cube = lpt.Cube(N=N)
+    cube = lpt.Cube(IC_rand_stream, N=N)
 times = _profiletime(None, 'initialization', times, comm, mpiproc)
 
 #### NOISE GENERATION
-delta = cube.generate_noise(seed=seed)
+delta = cube.generate_noise(mc=mc)
 times = _profiletime(None, 'noise generation', times, comm, mpiproc)
 
 #### NOISE CONVOLUTION TO OBTAIN DELTA

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 pname='lpt'
 setup(name=pname,
-      version='0.1',
+      version='0.2',
       description='Massively parallel GPU-enabled Lagrangian perturbation theory in Python using [jax.]numpy',
       url='http://github.com/exgalsky/lpt',
       author='exgalsky collaboration',


### PR DESCRIPTION
**This PR should be after the xgmutil [PR1](https://github.com/exgalsky/xgmutil/pull/2).** 

This is a refactor of the random number generation based of `xgmutil.random` module. This allows higher level control of random number streams with transparent tracking of metadata. This is demonstrated in the updated `scripts/example.py`. 

The `Cube` class needs to be initialized by passing a `RNG_component` object.
We now have an option for doing Monte Carlo by passing kwarg `mc`, to `Cube.generate_noise`.

Tested with MPI on CPU and GPUs.